### PR TITLE
Unit is not Unit

### DIFF
--- a/src/main/scala/gitbucket/gist/controller/GistController.scala
+++ b/src/main/scala/gitbucket/gist/controller/GistController.scala
@@ -254,7 +254,7 @@ trait GistControllerBase extends ControllerBase {
         .setOutputStream(response.getOutputStream)
         .call()
 
-      Unit
+      ()
     }
   }
 


### PR DESCRIPTION
scala.Unit is companion object of `()`

```
Welcome to Scala 2.11.8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_112).
Type in expressions for evaluation. Or try :help.

scala> val a = ()
a: Unit = ()

scala> val b = Unit
b: Unit.type = object scala.Unit

scala> a == b
<console>:14: warning: comparing values of types Unit and Unit.type using `==' will always yield false
       a == b
         ^
res1: Boolean = false
```