### PR TITLE
Delete AddPrimaryKey tag which is not required with not composite index

### DIFF
--- a/src/main/resources/update/gitbucket-gist_2.0.xml
+++ b/src/main/resources/update/gitbucket-gist_2.0.xml
@@ -24,14 +24,13 @@
   <createTable tableName="GIST_COMMENT">
     <column name="USER_NAME" type="varchar(100)" nullable="false"/>
     <column name="REPOSITORY_NAME" type="varchar(100)" nullable="false"/>
-    <column name="COMMENT_ID" type="int" nullable="false" autoIncrement="true" unique="true"/>
+    <column name="COMMENT_ID" type="int" nullable="false" autoIncrement="true" unique="true" primaryKeyName="IDX_GIST_COMMENT_PK" primaryKey="true" />
     <column name="COMMENTED_USER_NAME" type="varchar(100)" nullable="false"/>
     <column name="CONTENT" type="text" nullable="false"/>
     <column name="REGISTERED_DATE" type="datetime" nullable="false"/>
     <column name="UPDATED_DATE" type="datetime" nullable="false"/>
   </createTable>
 
-  <addPrimaryKey constraintName="IDX_GIST_COMMENT_PK" tableName="GIST_COMMENT" columnNames="COMMENT_ID"/>
   <addUniqueConstraint constraintName="IDX_GIST_COMMENT_1" tableName="GIST_COMMENT" columnNames="USER_NAME, REPOSITORY_NAME, COMMENT_ID"/>
   <addForeignKeyConstraint constraintName="IDX_GIST_COMMENT_FK0" baseTableName="GIST_COMMENT" baseColumnNames="USER_NAME, REPOSITORY_NAME" referencedTableName="GIST" referencedColumnNames="USER_NAME, REPOSITORY_NAME"/>
   <addForeignKeyConstraint constraintName="IDX_GIST_COMMENT_FK1" baseTableName="GIST_COMMENT" baseColumnNames="COMMENTED_USER_NAME" referencedTableName="ACCOUNT" referencedColumnNames="USER_NAME"/>


### PR DESCRIPTION
This PR is to fix liquibase execution with MariaDb which return a "Multi primary key" error (#60), 

Tested on :

H2 database
MariaDb ( Ver 15.1 Distrib 10.4.12-MariaDB, for Linux (x86_64) using readline 5.1 )

Before submitting a pull-request to GitBucket I have first:
- [X] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [X] rebased my branch over master
- [X] verified that project is compiling
- [X] verified that tests are passing
- [X] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [ ] [marked as closed using commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct